### PR TITLE
Refactor: Remove authentication requirement for account creation

### DIFF
--- a/app/routers/user.js
+++ b/app/routers/user.js
@@ -38,7 +38,6 @@ const {
 userManagerRouter
   // .post("/automate", upload.single("file"), goAutomate)
 
-  .post("/createAccount", authenticateToken, createAccountController)
   .get("/getAllAccounts", authenticateToken, getAllAccountsController)
   .put("/updateAccount", authenticateToken, updateAccountController)
   .post("/deleteAccount", authenticateToken, deleteAccountController)
@@ -50,6 +49,7 @@ userManagerRouter
   // .delete("/deleteClient", deleteClientController)
   // .put("/updateClient", updateClientController)
   
+  .post("/createAccount", createAccountController)
   .post("/send-otp", generateAndSendOtpController)
   .post("/verify-otp", verifyOTPController)
   .post("/newsletter", sendNewsletter)

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -40,16 +40,16 @@ export const createAccount = createAsyncThunk(
   async (clientData) => {
     // console.log("data from createAccount", { nombre, email, password });
     try {
-      const user = localStorage.getItem("user");
-      const userJson = JSON.parse(user);
-      const token = userJson.accessToken;
+      // const user = localStorage.getItem("user");
+      // const userJson = JSON.parse(user);
+      // const token = userJson.accessToken;
 
       const res = await apiBackend.post(
         `/user/createAccount`,
         { ...clientData },
         {
           headers: {
-            Authorization: `Bearer ${token}`,
+            // Authorization: `Bearer ${token}`,
           },
         }
       );


### PR DESCRIPTION
- Remove `authenticateToken` middleware from `/createAccount` route
- Update frontend API call to remove token authorization header
- Simplify account creation process by removing unnecessary authentication step